### PR TITLE
Semver branch matching

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,5 +8,5 @@
   "undef": true,
   "unused": true,
   "maxdepth": 2,
-  "maxcomplexity": 6
+  "maxcomplexity": 7
 }

--- a/build.js
+++ b/build.js
@@ -1,4 +1,4 @@
-var url = require('url'),
+var semver = require('semver'),
     exec = require('child_process').exec,
     parser = require('./parser');
 
@@ -72,8 +72,10 @@ Build.prototype.check_payload = function () {
   }
 
   // Check branch in payload matches branch in URL
-  var branch = url.parse(self.req.url).pathname.replace(/^\/|\/$/g, '') || 'master';
-  if (self.ui.data.branch !== branch) {
+  if (self.req.query.semver === undefined) {
+    self.req.query.branch = (self.req.query.branch || 'master');
+  }
+  if (!semver.valid(self.ui.data.branch) && self.ui.data.branch !== self.req.query.branch) {
     return error(400, 'Branches do not match');
   }
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "logging-tool": "~1.2.2",
     "minimist": "^1.2.0",
     "node-static": "^0.7.7",
+    "semver": "^5.1.0",
     "socket.io": "~1.4.4",
-    "string-format": "~0.5.0",
-    "validate-commit-msg": "^2.0.0"
+    "string-format": "~0.5.0"
   },
   "devDependencies": {
+    "validate-commit-msg": "^2.0.0",
     "codeclimate-test-reporter": "~0.3.0",
     "cracks": "^3.1.2",
     "cz-conventional-changelog": "^1.1.5",

--- a/payload.js
+++ b/payload.js
@@ -17,6 +17,7 @@ if (argv.h || argv.help) {
   console.log('-p|--port    port to send payload requests to');
   console.log('-t|--type    payload type to send (travis | github | error) - default github');
   console.log('-s|--secret  secret to add to URL');
+  console.log('--semver     match semver branch e.g. v1.2.3');
 
   process.exit();
 }
@@ -24,12 +25,14 @@ if (argv.h || argv.help) {
 var type = (argv.t || argv.type || 'github').toLowerCase();
 var port = parseInt(argv.p || argv.port || 6003);
 var secret = argv.s || argv.secret;
+var semver = argv.semver;
 
 var payload = {};
 var options = {
   hostname: 'localhost',
   port: port,
   path: '/',
+  query: {},
   method: 'POST'
 };
 
@@ -92,14 +95,21 @@ if (type === 'travis') {
 
 
 if (branch !== 'master' && Math.random() > 0.05) {
-  options.path += branch;
+  options.query.branch = branch;
 }
 
 if (secret) {
-  options.path += '?secret=' + secret;
+  options.query.secret = secret;
 }
 
+if (semver) {
+  options.query.semver = true;
+}
+
+options.path += '?' + qs.stringify(options.query);
+
 console.log('Sending payload', payload);
+console.log('HTTP options', options);
 http.request(options, function (res) {
   res.on('data', function (data) {
     console.log(data.toString());

--- a/test/common.js
+++ b/test/common.js
@@ -21,6 +21,7 @@ function data () {
     req.method = self.options.method;
     req.url = self.options.path;
     req.headers = self.options.headers;
+    req.query = self.options.query;
 
     build_manager.hook(req, res);
     req.end(payload);
@@ -50,7 +51,8 @@ function data () {
     path: '/',
     port: '6003',
     method: 'POST',
-    headers: {}
+    headers: {},
+    query: {}
   };
 }
 

--- a/test/github.js
+++ b/test/github.js
@@ -13,7 +13,7 @@ test('BEGIN GITHUB PAYLOAD TESTS', function (t) { t.end(); });
 test('pass string as payload', function (t) {
 
   var payload = 'asdf';
-  options.headers['x-hub-signature'] = gen_sig(config.github_secret, payload);
+  options.headers = {'x-hub-signature': gen_sig(config.github_secret, payload)};
 
   request(payload, function (res, data) {
     t.equal(data.err, 'Error: Invalid payload', 'correct server response');
@@ -26,7 +26,7 @@ test('pass string as payload', function (t) {
 test('pass invalid JSON object', function (t) {
 
   var payload = JSON.stringify({ property: 'false' });
-  options.headers['x-hub-signature'] = gen_sig(config.github_secret, payload);
+  options.headers = {'x-hub-signature': gen_sig(config.github_secret, payload)};
 
   request(payload, function (res, data) {
     t.equal(data.err, 'Error: Invalid data', 'correct server response');
@@ -40,7 +40,7 @@ test('pass valid JSON object but invalid signature', function (t) {
 
   t.test('valid secret but invalid payload', function (st) {
     var payload = JSON.stringify({ repository: { full_name: 'repo' }, ref: 'refs' });
-    options.headers['x-hub-signature'] = gen_sig(config.github_secret, 'asdf');
+    options.headers = {'x-hub-signature': gen_sig(config.github_secret, 'asdf')};
 
     request(payload, function (res, data) {
       st.equal(data.err, 'Error: Cannot verify payload signature', 'correct server response');
@@ -51,7 +51,7 @@ test('pass valid JSON object but invalid signature', function (t) {
 
   t.test('valid payload but invalid secret', function (st) {
     var payload = JSON.stringify({ repository: { full_name: 'repo' }, ref: 'refs' });
-    options.headers['x-hub-signature'] = gen_sig('asdf', payload);
+    options.headers = {'x-hub-signature': gen_sig('asdf', payload)};
 
     request(payload, function (res, data) {
       st.equal(data.err, 'Error: Cannot verify payload signature', 'correct server response');
@@ -66,7 +66,7 @@ test('pass valid JSON object and valid signature', function (t) {
 
   t.test('valid data but invalid branch ref', function (st) {
     var payload = JSON.stringify({ repository: { full_name: 'repo' }, ref: 'refs' });
-    options.headers['x-hub-signature'] = gen_sig(config.github_secret, payload);
+    options.headers = {'x-hub-signature': gen_sig(config.github_secret, payload)};
 
     request(payload, function (res, data) {
       st.equal(data.err, 'Branches do not match', 'correct server response');
@@ -77,7 +77,7 @@ test('pass valid JSON object and valid signature', function (t) {
 
   t.test('valid data and valid branch ref', function (st) {
     var payload = JSON.stringify({ repository: { full_name: 'repo' }, ref: 'refs/heads/master' });
-    options.headers['x-hub-signature'] = gen_sig(config.github_secret, payload);
+    options.headers = {'x-hub-signature': gen_sig(config.github_secret, payload)};
 
     request(payload, function (res, data) {
       st.equal(data.msg, 'Build queued', 'correct server response');
@@ -92,8 +92,8 @@ test('pass custom branch name', function (t) {
 
   t.test('valid branch in path but invalid branch ref', function (st) {
     var payload = JSON.stringify({ repository: { full_name: 'repo' }, ref: 'refs' });
-    options.path = '/dev';
-    options.headers['x-hub-signature'] = gen_sig(config.github_secret, payload);
+    options.query = {branch: 'dev'};
+    options.headers = {'x-hub-signature': gen_sig(config.github_secret, payload)};
 
     request(payload, function (res, data) {
       st.equal(data.err, 'Branches do not match', 'correct server response');
@@ -104,8 +104,8 @@ test('pass custom branch name', function (t) {
 
   t.test('valid branch in path and valid branch ref', function (st) {
     var payload = JSON.stringify({ repository: { full_name: 'repo' }, ref: 'refs/heads/dev' });
-    options.path = '/dev';
-    options.headers['x-hub-signature'] = gen_sig(config.github_secret, payload);
+    options.query = {branch: 'dev'};
+    options.headers = {'x-hub-signature': gen_sig(config.github_secret, payload)};
 
     request(payload, function (res, data) {
       st.equal(data.msg, 'Build queued', 'correct server response');

--- a/test/travis.js
+++ b/test/travis.js
@@ -123,7 +123,7 @@ test('pass custom branch name', function (t) {
     var payload = qs.stringify({ payload: JSON.stringify({ branch: 'master' }) });
     options.headers['authorization'] = gen_sig(config.travis_token, 'repo');
     options.headers['travis-repo-slug'] = 'repo';
-    options.path = '/dev';
+    options.query.branch = 'dev';
 
     request(payload, function (res, data) {
       st.equal(data.err, 'Branches do not match', 'correct server response');
@@ -136,20 +136,7 @@ test('pass custom branch name', function (t) {
     var payload = qs.stringify({ payload: JSON.stringify({ branch: 'dev' }) });
     options.headers['authorization'] = gen_sig(config.travis_token, 'repo');
     options.headers['travis-repo-slug'] = 'repo';
-    options.path = '/dev';
-
-    request(payload, function (res, data) {
-      st.equal(data.msg, 'Build queued', 'correct server response');
-      st.equal(res.statusCode, 202, 'correct status code');
-      st.end();
-    });
-  });
-
-  t.test('trailing slash in path', function (st) {
-    var payload = qs.stringify({ payload: JSON.stringify({ branch: 'dev' }) });
-    options.headers['authorization'] = gen_sig(config.travis_token, 'repo');
-    options.headers['travis-repo-slug'] = 'repo';
-    options.path = '/dev/';
+    options.query.branch = 'dev';
 
     request(payload, function (res, data) {
       st.equal(data.msg, 'Build queued', 'correct server response');


### PR DESCRIPTION
This adds the ability to specify to build on a semver matching branch (e.g. v1.2.3). It changes the existing way of specifying the branch to use the query string.

If both the semver flag and the branch flag are in the query string, the build will be run either if the branch in the payload matches semver or the branch flag passed. Also, if the neither the semver flag or the branch flag are passed, the branch will default to master as before.